### PR TITLE
지오펜싱 이벤트 등록할 메모 범위 증가

### DIFF
--- a/data/src/main/java/com/youngsik/jinada/data/datasource/remote/FirestoreMemoDataSourceImpl.kt
+++ b/data/src/main/java/com/youngsik/jinada/data/datasource/remote/FirestoreMemoDataSourceImpl.kt
@@ -1,7 +1,6 @@
 package com.youngsik.jinada.data.datasource.remote
 
 import android.location.Location
-import android.util.Log
 import com.firebase.geofire.GeoFireUtils
 import com.firebase.geofire.GeoLocation
 import com.google.android.gms.tasks.Tasks
@@ -106,7 +105,6 @@ class FirestoreMemoDataSourceImpl : MemoDataSource {
         val targetLocation = GeoLocation(location.latitude, location.longitude)
         val rangeDistanceInMeters = (range * 1000).toDouble()
         val queryBounds = GeoFireUtils.getGeoHashQueryBounds(targetLocation, rangeDistanceInMeters)
-        Log.d("jinada_test","getNearByMemoList nickname: ${nickname}")
 
         val tasks = queryBounds
             .map { bound ->
@@ -134,7 +132,7 @@ class FirestoreMemoDataSourceImpl : MemoDataSource {
                 }
             }
 
-        val memoList = nearbyMemos.filter { todoItemData -> changeToLocalDate(todoItemData.deadlineDate) >= LocalDate.now() }
+        val memoList = nearbyMemos.filter { todoItemData -> !todoItemData.isCompleted && changeToLocalDate(todoItemData.deadlineDate) >= LocalDate.now() }
 
         DataResourceResult.Success(memoList)
     }.getOrElse { DataResourceResult.Failure(it) }

--- a/presentation/src/main/java/com/youngsik/jinada/presentation/service/ActivityRecognitionService.kt
+++ b/presentation/src/main/java/com/youngsik/jinada/presentation/service/ActivityRecognitionService.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.launch
 class ActivityRecognitionService : Service(){
     companion object {
         private const val NOTIFICATION_ID = 10002
+        private const val SEARCHING_RANGE = 5.0f // 5km
         const val ACTION_UPDATE_GEOFENCING = "ACTION_UPDATE_GEOFENCING"
     }
 
@@ -67,7 +68,7 @@ class ActivityRecognitionService : Service(){
                         if (settings.closerNotificationEnabled){
                             val location = (locationRepository as CurrentLocationRepositoryImpl).getCurrentLocation()
                             if (location != null){
-                                memoRepository.getNearByMemoList(userInfo.nickname,location,settings.closerMemoSearchingRange).collect { result ->
+                                memoRepository.getNearByMemoList(userInfo.nickname,location,SEARCHING_RANGE).collect { result ->
                                     when (result) {
                                         is DataResourceResult.Success -> {
                                             if (ActivityCompat.checkSelfPermission(applicationContext,Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {

--- a/presentation/src/main/java/com/youngsik/jinada/presentation/viewmodel/MemoMapViewModel.kt
+++ b/presentation/src/main/java/com/youngsik/jinada/presentation/viewmodel/MemoMapViewModel.kt
@@ -80,10 +80,7 @@ class MemoMapViewModel(application: Application, private val memoRepository: Mem
             memoRepository.getNearByMemoList(_mapUiState.value.nickname,myLocation,range).collect { result ->
                 when(result){
                     is DataResourceResult.Loading -> _mapUiState.update { it.copy(isLoading = true) }
-                    is DataResourceResult.Success -> {
-                        val nearByMemoList = result.data.filter { todoItemData -> !todoItemData.isCompleted }
-                        _mapUiState.update { it.copy(isLoading = false, isSuccessful = true, nearByMemoList = nearByMemoList) }
-                    }
+                    is DataResourceResult.Success -> _mapUiState.update { it.copy(isLoading = false, isSuccessful = true, nearByMemoList = result.data.sortedBy { it -> it.distance }) }
                     is DataResourceResult.Failure -> _mapUiState.update { it.copy(isLoading = false, isFailure = true) }
                 }
             }


### PR DESCRIPTION
지오펜싱 이벤트 등록할 메모 범위 증가
  - 기존 사용자 설정 값(100~500m) -> 5km로 변경
  - 이동 상태 진입 판단이 자주 일어나지않아 메모 등록 이벤트가 일어나지 않는 문제 해결

메인화면 근처 메모 목록 거리 기준으로 정렬 추가